### PR TITLE
chore(db): add sqlite schema and test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 __pycache__
 .DS_Store
 coverage/
+hospital.db

--- a/db/schema-sqlite.sql
+++ b/db/schema-sqlite.sql
@@ -1,0 +1,32 @@
+-- db/schema-sqlite.sql - SQLite version of schema
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  role TEXT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS patients (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  full_name TEXT NOT NULL,
+  dob DATE,
+  gender TEXT,
+  contact TEXT,
+  address TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS appointments (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  patient_id INTEGER,
+  doctor_id INTEGER,
+  scheduled_at DATETIME NOT NULL,
+  reason TEXT,
+  status TEXT DEFAULT 'scheduled',
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(patient_id) REFERENCES patients(id) ON DELETE SET NULL,
+  FOREIGN KEY(doctor_id)  REFERENCES users(id)    ON DELETE SET NULL
+);

--- a/scripts/test_db.py
+++ b/scripts/test_db.py
@@ -1,0 +1,31 @@
+# scripts/test_db.py
+import sqlite3
+from datetime import date
+from pathlib import Path
+
+# find repo root (one level up from scripts/)
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DB = str(REPO_ROOT / "hospital.db")
+
+def init_and_insert():
+    conn = sqlite3.connect(DB)
+    conn.execute("PRAGMA foreign_keys = ON;")
+    cur = conn.cursor()
+
+    # insert a sample patient
+    cur.execute("""
+        INSERT INTO patients (full_name, dob, gender, contact, address)
+        VALUES (?, ?, ?, ?, ?)
+    """, ("Test Patient", "1990-01-01", "Other", "9999999999", "123 Demo Street"))
+    conn.commit()
+
+    # fetch and print patients
+    cur.execute("SELECT id, full_name, dob, contact, created_at FROM patients;")
+    rows = cur.fetchall()
+    for r in rows:
+        print(r)
+
+    conn.close()
+
+if __name__ == "__main__":
+    init_and_insert()


### PR DESCRIPTION
This PR:
- Adds SQLite schema at `db/schema-sqlite.sql` (users, patients, appointments).
- Adds a small test script at `scripts/test_db.py` to insert/read a patient.
- Adds `hospital.db` to `.gitignore` so the DB file isn't tracked.

How to test locally:
1. sqlite3 hospital.db < db/schema-sqlite.sql
2. python3 scripts/test_db.py

Closes: #<issue-number>   <!-- replace with your DB Schema & Migrations issue number -->
